### PR TITLE
Point out brittleness in environment unit test

### DIFF
--- a/src/test/java/com/barinek/flagship/EnvironmentTest.java
+++ b/src/test/java/com/barinek/flagship/EnvironmentTest.java
@@ -18,7 +18,7 @@ public class EnvironmentTest {
         Injector injector = Guice.createInjector(new TestEnvironment("test"));
         A a = injector.getInstance(A.class);
         assertEquals("42", a.getValue());
-        assertEquals("/bin/bash", a.getShell());
+        assertEquals("/bin/bash", a.getShell()); //This is somewhat brittle
     }
 
     class TestEnvironment extends Environment {


### PR DESCRIPTION
This isn't an actual pull request, but there wasn't a way to open a github issue on this repo.

I just wanted to point out that this test will not work if I set my SHELL env var to something other than /bin/bash.
This probably falls over in windows too. If you care about it, there is probably a solution.

Processbuilder allows you to specify an env for a subprocess, so you could try fiddling around with that. 

OR 
you could inject an EnvironmentVariableProvider Interface, to which you'd implement a fake in the unit test. Then you'd have a tiny implementation class as follows:
public class SystemEnvironmentVariableProvider implements EnvironmentVariableProvider {
   public string getEnv(String envVarName) { return System.getEnv(envVarName);} 
}