### PR TITLE
Don’t restrict environments unnecessarily

### DIFF
--- a/src/main/java/com/barinek/flagship/App.java
+++ b/src/main/java/com/barinek/flagship/App.java
@@ -54,10 +54,6 @@ public class App {
 
         logger.info("Found {} environment.", env);
 
-        List<String> environments = Lists.newArrayList("development", "test", "production");
-        if (!environments.contains(env)) {
-            throw new RuntimeException("Unknown environmentArg.");
-        }
         return new Environment(env);
     }
 


### PR DESCRIPTION
Though I haven't actually tested this PR thoroughly, there doesn't seem to be any reason to limit the environments to a finite set. 

The development, test, and production environments are just conventional, but often rails apps have multiple environments. Some of our Spring Boot apps on my current project have a number of Profiles (which are analogous to rails environments).