### PR TITLE
Closed connection for neatness

### DIFF
--- a/src/test/java/com/barinek/flagship/AppTest.java
+++ b/src/test/java/com/barinek/flagship/AppTest.java
@@ -14,11 +14,17 @@ import static org.junit.Assert.assertEquals;
 public class AppTest extends AppRunner {
     @Test
     public void basicApp() throws IOException {
+
         HttpClient httpclient = new DefaultHttpClient();
-        HttpGet httpget = new HttpGet("http://localhost:8080");
-        ResponseHandler<String> responseHandler = new BasicResponseHandler();
-        String responseBody = httpclient.execute(httpget, responseHandler);
-        assertEquals("Noop!", responseBody);
+
+        try {
+            HttpGet httpget = new HttpGet("http://localhost:8080");
+            ResponseHandler<String> responseHandler = new BasicResponseHandler();
+            String responseBody = httpclient.execute(httpget, responseHandler);
+            assertEquals("Noop!", responseBody);
+        } finally {
+            httpclient.getConnectionManager().shutdown();
+        }
     }
 }
 


### PR DESCRIPTION
When HttpClient instance is no longer needed, shut down the connection manager to ensure immediate deallocation of all system resources. 

Mostly just for neatness and consistency in this case. The shutdown() method has been called in all the all the other tests.